### PR TITLE
Fixes source and destination path variables in "RSAT Smart Cab Extract.ps1"

### DIFF
--- a/RSAT Smart Cab Extract.ps1
+++ b/RSAT Smart Cab Extract.ps1
@@ -46,11 +46,12 @@ $additionalFiles = @(
 )
 
 foreach ($file in $additionalFiles) {
-    $filePath = Join-Path -Path $sourcePath -ChildPath $file
+    $filePath = Join-Path -Path $sourceFolder -ChildPath $file
     if (Test-Path -Path $filePath) {
-        Copy-Item -Path $filePath -Destination $destinationPath
+        Copy-Item -Path $filePath -Destination $destinationFolder
+        Write-Host "Copied: $(file)"
     } else {
-        Write-Host "File $file not found in $sourcePath"
+        Write-Host "File $file not found in $sourceFolder"
     }
 }
 

--- a/Windows 11 RSAT FOD Offline Install.ps1
+++ b/Windows 11 RSAT FOD Offline Install.ps1
@@ -19,6 +19,6 @@ $RSAT_FoD = Get-WindowsCapability -Name RSAT.* -Online -Source $FoD_Source
 #Install RSAT Tools
 Foreach ($RSAT_FoD_Item in $RSAT_FoD)
 {
-Add-WindowsCapability -Online -Name $RSAT_FoD_Item.name -Source $FodSource -LimitAccess
+Add-WindowsCapability -Online -Name $RSAT_FoD_Item.name -Source $FoD_Source -LimitAccess
 }
 


### PR DESCRIPTION
Fixes source and destination path variables in both scripts.

### RSAT Smart Cab Extract:
$additionalFiles foreach loop was using $sourcePath and $destinationPath variables which were never defined, thus throwing an error. Changing to $sourceFolder and $destinationFolder allows script to execute successfully.

Additionally added a write-host line to output what files were copied.

### Windows 11 RSAT FOD Offline Install.ps1
$FoD_Source path in foreach loop was referenced as $FoDSource, resulting in errors for each capability. 
Changing `Add-WindowsCapability -Online -Name $RSAT_FoD_Item.name -Source $FoDSource -LimitAccess` 
to `Add-WindowsCapability -Online -Name $RSAT_FoD_Item.name -Source $FoD_Source -LimitAccess` fixes the error.