### PR TITLE
Fixed Write-Host Output for $additionalFiles

### DIFF
--- a/RSAT Smart Cab Extract.ps1
+++ b/RSAT Smart Cab Extract.ps1
@@ -49,7 +49,7 @@ foreach ($file in $additionalFiles) {
     $filePath = Join-Path -Path $sourceFolder -ChildPath $file
     if (Test-Path -Path $filePath) {
         Copy-Item -Path $filePath -Destination $destinationFolder
-        Write-Host "Copied: $(file)"
+        Write-Host "Copied: $($file)"
     } else {
         Write-Host "File $file not found in $sourceFolder"
     }


### PR DESCRIPTION
The `foreach` loop that copies files from `$additionalFiles` had a typo with the `Write-Host` syntax that caused it to fail (_looks like there's an issue about it too_). I just added an additional `$` within the parenthesis to fix it. 

Major props and thanks for creating this guide and these scripts!